### PR TITLE
[bug] Wrong docker-compose default environment

### DIFF
--- a/devops/docker-compose.yml
+++ b/devops/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       dockerfile: ./devops/dockerfile
     container_name: camaleaoapi
     environment:
-      - ASPNETCORE_ENVIRONMENT=Release
+      - ASPNETCORE_ENVIRONMENT=Docker
     ports:
       - "5000:5000"
     links:


### PR DESCRIPTION
| Questions | Answers
| ------------- 	  | -------------------------------------------------------
| Issues        	  | https://github.com/mundipagg/camaleao/issues/41
| Whats?   | Fixes application startup.
| Why? | Because using default flow to run it (described in project readme.md), must be working fine.
| How?     | Changing `devops/docker-compose.yml` default environment from `Release` to `Docker`

#### Status

DONE!
